### PR TITLE
Features/body hash

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -52,7 +52,12 @@ export namespace Utils {
      */
     export function getParameterString(request: any, oauth_data: any) {
         let parsedUrl = url.parse(request.url, true);
-        let data = Object.assign({}, parsedUrl.query, request.data || {}, oauth_data);
+        // If we are using body hashing then request.data will be a string that should be the exact
+        // text of the request body (after decompression) rather than a set of key value pairs.
+        // In this case we take a hash of the body itself and include it in the oauth_data.
+        // http://web.archive.org/web/20160413130001/https://oauth.googlecode.com/svn/spec/ext/body_hash/1.0/oauth-bodyhash.html
+        const requestData = request.includeBodyHash ? undefined : request.data;
+        let data = Object.assign({}, parsedUrl.query, requestData || {}, oauth_data);
         // These OAuth fields should be ignored when computing signatures even
         // if they are present in the data passed to the `authorize` method.
         [


### PR DESCRIPTION
Things to look for:

I tried to match the existing style as closely as possible but I'm not as familiar with javascript/typescript idioms as you are so feel free to update anything to make it match more closely.

In utils.ts/getParameterString I check request.includeBodyHash to determine if we should exclude the body from the parameter string. Technically according to spec we should be checking to see if the message is url encoded. Pretty much all the time though you will either make an url encoded request without body hashing or use some other request and include body hashing. So for practical purposes it should always line up. Technically right now though if you send a non-url encoded request, try to send the contents in the RequestOpts and don't set includeBodyHash to true it will do the wrong thing. I think we could just consider that to be using the library wrong but I thought I'd mention it to see what you think.